### PR TITLE
Add support for router key generation

### DIFF
--- a/cmd/router/example-config.yaml
+++ b/cmd/router/example-config.yaml
@@ -19,6 +19,8 @@ log:
     timestamp: true
 
 router:
+  keyfile: /etc/thingsix-router/router.key
+
   forwarder:
     endpoint:
       host: 0.0.0.0

--- a/cmd/router/key.go
+++ b/cmd/router/key.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,26 +18,17 @@ package main
 
 import (
 	"github.com/ThingsIXFoundation/packet-handling/router"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "router",
-	Short: "run the router service",
-	Args:  cobra.RangeArgs(0, 1),
-	Run:   router.Run,
+var keyCmd = &cobra.Command{
+	Use:   "key",
+	Short: "key commands",
 }
 
-func init() {
-	keyCmd.AddCommand(genKeyCmd)
-	rootCmd.AddCommand(keyCmd)
-
-	rootCmd.PersistentFlags().String("config", "", "configuration file")
-	err := viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
-	if err != nil {
-		logrus.WithError(err).Fatal("could not find viper flag")
-	}
+var genKeyCmd = &cobra.Command{
+	Use:   "generate [keyfile]",
+	Short: "Generate router key",
+	Args:  cobra.RangeArgs(0, 1),
+	Run:   router.GenerateKey,
 }

--- a/forwarder/exchange.go
+++ b/forwarder/exchange.go
@@ -21,8 +21,10 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/ThingsIXFoundation/packet-handling/airtime"
 	"github.com/ThingsIXFoundation/packet-handling/external/chirpstack/gateway-bridge/backend/events"
+	"github.com/ThingsIXFoundation/packet-handling/gateway"
 	"github.com/ThingsIXFoundation/packet-handling/utils"
 	"github.com/ThingsIXFoundation/router-api/go/router"
 	"github.com/brocaar/lorawan"
@@ -372,7 +374,7 @@ func init() {
 // is online this callback is called.ys
 func (e *Exchange) subscribeEvent(event events.Subscribe) {
 	log := logrus.WithField("gw_local_id", hex.EncodeToString(event.GatewayID[:]))
-	localGatewayID, err := utils.BytesToGatewayID(event.GatewayID[:])
+	localGatewayID, err := gateway.BytesToGatewayID(event.GatewayID[:])
 	if err != nil {
 		log.Warn("event from gateway with invalid local id, drop event")
 		return

--- a/gateway/utils.go
+++ b/gateway/utils.go
@@ -17,7 +17,6 @@
 package gateway
 
 import (
-	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -25,10 +24,8 @@ import (
 
 	gateway_registry "github.com/ThingsIXFoundation/gateway-registry-go"
 	h3light "github.com/ThingsIXFoundation/h3-light"
-	"github.com/ThingsIXFoundation/packet-handling/utils"
 	"github.com/brocaar/lorawan"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/olekukonko/tablewriter"
 	"github.com/sirupsen/logrus"
 )
@@ -41,27 +38,13 @@ type Config struct {
 	} `mapstructure:"blockchain"`
 }
 
-func GeneratePrivateKey() (*ecdsa.PrivateKey, error) {
-	for {
-		priv, err := crypto.GenerateKey()
-		if err != nil {
-			return nil, err
-		}
-
-		compressedPub := crypto.CompressPubkey(&priv.PublicKey)
-		if compressedPub[0] == 0x02 {
-			return priv, nil
-		}
-	}
-}
-
 func mustDecodeGatewayID(input string) lorawan.EUI64 {
 	bytes, err := hex.DecodeString(input)
 	if err != nil {
 		logrus.WithError(err).Fatal("invalid gateway local id")
 	}
 
-	id, err := utils.BytesToGatewayID(bytes)
+	id, err := BytesToGatewayID(bytes)
 	if err != nil {
 		logrus.WithError(err).Fatal("invalid gateway local id")
 	}

--- a/router/cmd.go
+++ b/router/cmd.go
@@ -25,12 +25,30 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+func GenerateKey(cmd *cobra.Command, args []string) {
+	filename := "/etc/thingsix-router/router.key" // default location
+	// if config contains keyfile overwrite default
+	if configFile := viper.GetString("config"); configFile != "" {
+		cfg := mustLoadConfig()
+		if cfg.Router.Keyfile != "" {
+			filename = cfg.Router.Keyfile
+		}
+	}
+	// if location as argument is given use that
+	if len(args) == 1 {
+		filename = args[0]
+	}
+
+	mustGenerateKey(filename)
+}
 
 func Run(cmd *cobra.Command, args []string) {
 	var (
 		ctx, shutdown    = context.WithCancel(context.Background())
-		cfg              = mustLoadConfig(args)
+		cfg              = mustLoadConfig()
 		wg               sync.WaitGroup
 		sign             = make(chan os.Signal, 1)
 		integration, err = buildIntegrations(cfg)

--- a/router/config.go
+++ b/router/config.go
@@ -28,6 +28,8 @@ import (
 )
 
 type RouterConfig struct {
+	Keyfile string `yaml:"key_file"`
+
 	JoinFilterGenerator struct {
 		RenewInterval time.Duration `mapstructure:"renew_interval"`
 		ChirpStack    struct {
@@ -122,7 +124,7 @@ type Config struct {
 	Metrics *struct {
 		Prometheus *struct {
 			Address string
-			Path string
+			Path    string
 		}
 	}
 }
@@ -147,7 +149,7 @@ func (cfg Config) MetricsPrometheusPath() string {
 	return path
 }
 
-func mustLoadConfig(args []string) *Config {
+func mustLoadConfig() *Config {
 	viper.SetConfigName("config") // name of config file (without extension)
 	viper.SetConfigType("yaml")   // REQUIRED if the config file does not have the extension in the name
 

--- a/router/key.go
+++ b/router/key.go
@@ -1,0 +1,92 @@
+// Copyright 2022 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ThingsIXFoundation/packet-handling/utils"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type Identity struct {
+	ID         string            `yaml:"id"`
+	PrivateKey *ecdsa.PrivateKey `yaml:"private_key"`
+}
+
+type Keyfile struct {
+	Router struct {
+		ID         string `yaml:"id"`
+		PrivateKey string `yaml:"private_key"`
+	}
+}
+
+func mustGenerateKey(filename string) {
+	if _, err := os.Stat(filename); errors.Is(err, os.ErrNotExist) {
+		outputFile, err := os.Create(filename)
+		if err != nil {
+			logrus.WithError(err).Fatalf("unable to open output file %s", filename)
+		}
+		defer outputFile.Close()
+
+		key, err := utils.GeneratePrivateKey()
+		if err != nil {
+			logrus.WithError(err).Fatal("unable to generate key")
+		}
+
+		// serialize gateway details
+		var keyfile Keyfile
+		keyfile.Router.ID = hex.EncodeToString(utils.CalculateCompressedPublicKeyBytes(&key.PublicKey))
+		keyfile.Router.PrivateKey = hex.EncodeToString(crypto.FromECDSA(key))
+		if err := yaml.NewEncoder(outputFile).Encode(keyfile); err != nil {
+			logrus.WithError(err).Fatalf("unable to write router key to %s", filename)
+		}
+		fmt.Printf("router key written to: %s\n", filename)
+		fmt.Printf("router id: %s\n", keyfile.Router.ID)
+	} else {
+		logrus.Fatalf("output file %s already exists", filename)
+	}
+}
+
+func loadRouterIdentity(cfg *Config) (*Identity, error) {
+	var keyfile Keyfile
+	file, err := os.Open(cfg.Router.Keyfile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open router keyfile '%s'", cfg.Router.Keyfile)
+	}
+	defer file.Close()
+
+	if err := yaml.NewDecoder(file).Decode(&keyfile); err != nil {
+		return nil, fmt.Errorf("unable to decode router keyfile")
+	}
+
+	key, err := crypto.HexToECDSA(keyfile.Router.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode router private key from keyfile %s", cfg.Router.Keyfile)
+	}
+
+	return &Identity{
+		ID:         hex.EncodeToString(utils.CalculateCompressedPublicKeyBytes(&key.PublicKey)),
+		PrivateKey: key,
+	}, nil
+}

--- a/utils/thingsix.go
+++ b/utils/thingsix.go
@@ -17,35 +17,15 @@
 package utils
 
 import (
+	"crypto/ecdsa"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/binary"
-	"fmt"
+
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sirupsen/logrus"
 
 	"github.com/brocaar/lorawan"
 )
-
-func GatewayPublicKeyToID(pubKey []byte) (lorawan.EUI64, error) {
-	// pubkey is the compressed 33-byte long public key,
-	// the gateway ID is the pub key without the 0x02 prefix
-	if len(pubKey) == 33 {
-		// compressed ThingsIX public keys always start with 0x02.
-		// therefore don't use it and use bytes [1:] to derive the id
-		h := sha256.Sum256(pubKey[1:])
-		return BytesToGatewayID(h[:8])
-	}
-	return lorawan.EUI64{}, fmt.Errorf("invalid gateway public key (len=%d)", len(pubKey))
-}
-
-func BytesToGatewayID(id []byte) (lorawan.EUI64, error) {
-	var gid lorawan.EUI64
-	if len(id) != len(gid) {
-		return lorawan.EUI64{}, fmt.Errorf("invalid gateway id length (len=%d)", len(id))
-	}
-	copy(gid[:], id)
-	return gid, nil
-}
 
 // Eui64ToUint64 converts a lorawan.EUI64 into an uint64 in BigEndian format.
 func Eui64ToUint64(eui64 lorawan.EUI64) uint64 {
@@ -70,4 +50,26 @@ func RandUint32() uint32 {
 		logrus.WithError(err).Fatal("could not generate random number")
 	}
 	return binary.BigEndian.Uint32(b)
+}
+
+func GeneratePrivateKey() (*ecdsa.PrivateKey, error) {
+	for {
+		priv, err := crypto.GenerateKey()
+		if err != nil {
+			return nil, err
+		}
+
+		compressedPub := crypto.CompressPubkey(&priv.PublicKey)
+		if compressedPub[0] == 0x02 {
+			return priv, nil
+		}
+	}
+}
+
+func CalculateCompressedPublicKeyBytes(pub *ecdsa.PublicKey) []byte {
+	return crypto.CompressPubkey(pub)[1:]
+}
+
+func CalculatePublicKeyBytes(pub *ecdsa.PublicKey) []byte {
+	return crypto.FromECDSAPub(pub)
 }


### PR DESCRIPTION
Add support for router identity generation.

```bash
$ router key generate /my/path/to/router.key
```

Add `/my/path/to/router.key` to the configuration file with key `router.keyfile`.