### PR TITLE
Add support for setting environments via single parameter

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -38,9 +38,10 @@ the gateway.`,
 
 func init() {
 	rootCmd.PersistentFlags().String("config", "", "configuration file")
-	err := viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
-	if err != nil {
-		logrus.WithError(err).Fatal("could not find viper flag")
+	rootCmd.PersistentFlags().String("net", "main", "the network to load the default parameters for (\"dev\", \"test\", \"main\" or \"\")")
+
+	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
+		logrus.WithError(err).Fatal("could not bind command line flags")
 	}
 
 	rootCmd.AddCommand(gateway.Cmd)

--- a/cmd/forwarder/root.go
+++ b/cmd/forwarder/root.go
@@ -38,31 +38,10 @@ func init() {
 	cobra.OnInitialize(initConfig)
 }
 
-var cfgFile string
-
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".packet-exchange" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".packet-exchange")
-	}
-
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
 }
 
 func main() {

--- a/forwarder/config.go
+++ b/forwarder/config.go
@@ -17,110 +17,14 @@
 package forwarder
 
 import (
-	"os"
 	"time"
 
 	"github.com/ThingsIXFoundation/packet-handling/utils"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/icza/gog"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
-
-type Config struct {
-	Forwarder struct {
-		// Backend holdsconfiguration related to the forwarders gateway
-		// endpoint and supported protocol.
-		Backend struct {
-			SemtechUDP *struct {
-				UDPBind    *string `mapstructure:"udp_bind"`
-				FakeRxTime *bool   `mapstructure:"fake_rx_time"`
-			} `mapstructure:"semtech_udp"`
-
-			BasicStation  *struct{} `mapstructure:"basic_station"`
-			Concentratord *struct{} `mapstructure:"concentratord"`
-		}
-
-		// Gateways holds configuration related to gateways.
-		Gateways struct {
-			// Store describes how gateways are stored/loaded in the forwarder.
-			Store struct {
-				// YamlStorePath indicates that gateways are stored in a
-				// YAML based file store located on the local file system.
-				// Only data for gateways in the store is forwarded.
-				YamlStorePath *string `mapstructure:"file"`
-			}
-
-			// RecordUnknown records gateways that connect to the forwarder but
-			// are not in the forwarders gateway store. Recorded gateways can
-			// be imported later if required.
-			RecordUnknown *struct {
-				// File points to a file on the local file system where
-				// unknown gateways that connect are recorded.
-				File string
-			} `mapstructure:"record_unknown"`
-			// RegistryAddress holds the address where the gateway registry is
-			// deployed on chain. It is used to retrieve gateway details to
-			// determine which gateways in the store are onboarded on ThingsIX
-			// and have their details. Once token support is integrated to ThingsIX
-			// only data for these gateways will be forwarded.
-			RegistryAddress *common.Address `mapstructure:"gateway_registry"`
-
-			// Refresh indicates the interval in which the gateway registry is
-			// used to check if gateways from the forwarders store are onboarded
-			// have their gateways set.
-			Refresh *time.Duration
-		}
-
-		Routers struct {
-			// Default routers that will receive all gateway data unfiltered
-			Default []*Router
-
-			// OnChain idicates that ThingsIX routers are loaded from the router
-			// registry as deployed on the blockchain.
-			OnChain *struct {
-				// RegistryContract indicates when non-nil that router information must
-				// be fetched from the registry smart contract (required blockchain cfg)
-				RegistryContract common.Address `mapstructure:"registry"`
-
-				// Interval indicates how often the routes are refreshed
-				UpdateInterval *time.Duration `mapstructure:"interval"`
-			} `mapstructure:"on_chain"`
-
-			// ThingsIXApi indicates when non-nil that router information must be
-			// fetched from the ThingsIX API
-			ThingsIXApi *struct {
-				Endpoint *string
-				// Interval indicates how often the routes are refreshed
-				UpdateInterval *time.Duration `mapstructure:"interval"`
-			} `mapstructure:"thingsix_api"`
-		}
-
-		// Optional account strategy configuration, if not specified no account is used meaning
-		// that all packets are exchanged between gateway and routers.
-		Accounting *struct{}
-	}
-
-	Log struct {
-		Level     logrus.Level
-		Timestamp bool
-	}
-
-	BlockChain struct {
-		Polygon *struct {
-			Endpoint      string
-			ChainID       uint64 `mapstructure:"chain_id"`
-			Confirmations uint64
-		}
-	}
-
-	Metrics *struct {
-		Prometheus *struct {
-			Address string
-			Path    string
-		}
-	}
-}
 
 func (cfg Config) PrometheusEnabled() bool {
 	return cfg.Metrics != nil &&
@@ -142,38 +46,94 @@ func (cfg Config) MetricsPrometheusPath() string {
 	return path
 }
 
+func getNetConfig(net string) *Config {
+	var cfg = Config{}
+	if net == "" {
+		return &cfg
+	}
+	cfg.Forwarder = ForwarderConfig{}
+	cfg.Forwarder.Backend = ForwarderBackendConfig{}
+	cfg.Forwarder.Backend.SemtechUDP = &ForwarderBackendSemtechUDPConfig{}
+	cfg.Forwarder.Backend.SemtechUDP.UDPBind = gog.Ptr("0.0.0.0:1680")
+	cfg.Forwarder.Backend.SemtechUDP.FakeRxTime = gog.Ptr(false)
+	cfg.Forwarder.Gateways = ForwarderGatewayConfig{}
+	cfg.Forwarder.Gateways.Store = ForwarderGatewayStoreConfig{}
+	cfg.Forwarder.Gateways.Store.YamlStorePath = gog.Ptr("/etc/thingsix-forwarder/gateways.yaml")
+	cfg.Forwarder.Gateways.RecordUnknown = &ForwarderGatewayRecordUnknownConfig{}
+	cfg.Forwarder.Gateways.RecordUnknown.File = "/etc/thingsix-forwarder/unknown_gateways.yaml"
+	cfg.Forwarder.Routers = ForwarderRoutersConfig{}
+	cfg.Forwarder.Routers.ThingsIXApi = &ForwarderRoutersThingsIXAPIConfig{}
+	cfg.Forwarder.Routers.ThingsIXApi.UpdateInterval = gog.Ptr(30 * time.Minute)
+	cfg.BlockChain = BlockchainConfig{}
+	cfg.BlockChain.Polygon = &BlockchainPolygonConfig{}
+	cfg.BlockChain.Polygon.Confirmations = 128
+	cfg.Log = LogConfig{}
+	cfg.Log.Level = logrus.InfoLevel
+	cfg.Log.Timestamp = true
+	cfg.Metrics = &MetricsConfig{}
+	cfg.Metrics.Prometheus = &MetricsPrometheusConfig{}
+	cfg.Metrics.Prometheus.Address = "0.0.0.0:8888"
+	cfg.Metrics.Prometheus.Path = "/metrics"
+
+	if net == "main" {
+		cfg.Forwarder.Routers.ThingsIXApi.Endpoint = gog.Ptr("https://api.thingsix.com/routers/v1/snapshot")
+		cfg.BlockChain.Polygon.Endpoint = "https://polygon-rpc.com"
+		cfg.BlockChain.Polygon.ChainID = 137
+		return &cfg
+	}
+	if net == "test" {
+		cfg.Forwarder.Routers.ThingsIXApi.Endpoint = gog.Ptr("https://api-testnet.thingsix.com/routers/v1/snapshot")
+		cfg.BlockChain.Polygon.Endpoint = "https://rpc.ankr.com/polygon_mumbai"
+		cfg.BlockChain.Polygon.ChainID = 80001
+		return &cfg
+	}
+	if net == "dev" {
+		cfg.Forwarder.Routers.ThingsIXApi.Endpoint = gog.Ptr("https://api-devnet.thingsix.com/routers/v1/snapshot")
+		cfg.BlockChain.Polygon.Endpoint = "https://rpc.ankr.com/polygon_mumbai"
+		cfg.BlockChain.Polygon.ChainID = 80001
+		return &cfg
+	}
+
+	logrus.Fatalf("invalid net: %s, valid options are: main, test, dev and \"\"", net)
+	return nil
+}
+
 func mustLoadConfig() *Config {
 	viper.SetConfigName("config") // name of config file (without extension)
 	viper.SetConfigType("yaml")   // REQUIRED if the config file does not have the extension in the name
 
-	if home, err := os.UserHomeDir(); err == nil {
-		viper.AddConfigPath(home) // call multiple times to add many search paths
-	}
-	viper.AddConfigPath("/etc/thingsix-forwarder/") // path to look for the config file in
-	viper.AddConfigPath(".")
+	net := viper.GetString("net")
+	cfg := getNetConfig(net)
 
 	if configFile := viper.GetString("config"); configFile != "" {
 		viper.SetConfigFile(configFile)
-	}
 
-	if err := viper.ReadInConfig(); err != nil {
-		logrus.WithError(err).Fatal("unable to read config")
-	}
+		if err := viper.ReadInConfig(); err != nil {
+			logrus.WithError(err).Fatal("unable to read config")
+		}
 
-	var cfg Config
-	if err := viper.Unmarshal(&cfg, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
-		mapstructure.StringToSliceHookFunc(","),
-		utils.StringToEthereumAddressHook(),
-		utils.IntToBigIntHook(),
-		utils.HexStringToBigIntHook(),
-		utils.StringToHashHook(),
-		utils.StringToDuration(),
-		utils.StringToLogrusLevel()))); err != nil {
-		logrus.WithError(err).Fatal("unable to load configuration")
+		if err := viper.Unmarshal(cfg, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToSliceHookFunc(","),
+			utils.StringToEthereumAddressHook(),
+			utils.IntToBigIntHook(),
+			utils.HexStringToBigIntHook(),
+			utils.StringToHashHook(),
+			utils.StringToDuration(),
+			utils.StringToLogrusLevel()))); err != nil {
+			logrus.WithError(err).Fatal("unable to load configuration")
+		}
+	} else if net == "" {
+		logrus.Fatal("neither a default network nor a config-file where provided. Provide at least one.")
 	}
 
 	logrus.SetLevel(cfg.Log.Level)
 	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: cfg.Log.Timestamp})
+
+	if net != "" {
+		logrus.Infof("***Starting ThingsIX Forwarder connected to %snet***", net)
+	} else {
+		logrus.Info("***Starting ThingsIX Forwarder connected to unknown net***")
+	}
 
 	// ensure user provided polygon blockchain config
 	if cfg.BlockChain.Polygon == nil {
@@ -186,5 +146,5 @@ func mustLoadConfig() *Config {
 		r.Default = true
 	}
 
-	return &cfg
+	return cfg
 }

--- a/forwarder/config_type.go
+++ b/forwarder/config_type.go
@@ -1,0 +1,146 @@
+// Copyright 2022 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package forwarder
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sirupsen/logrus"
+)
+
+type ForwarderBackendSemtechUDPConfig struct {
+	UDPBind    *string `mapstructure:"udp_bind"`
+	FakeRxTime *bool   `mapstructure:"fake_rx_time"`
+}
+
+type ForwarderBackendConfig struct {
+	SemtechUDP    *ForwarderBackendSemtechUDPConfig `mapstructure:"semtech_udp"`
+	BasicStation  *struct{}                         `mapstructure:"basic_station"`
+	Concentratord *struct{}                         `mapstructure:"concentratord"`
+}
+
+type ForwarderGatewayStoreConfig struct {
+	// YamlStorePath indicates that gateways are stored in a
+	// YAML based file store located on the local file system.
+	// Only data for gateways in the store is forwarded.
+	YamlStorePath *string `mapstructure:"file"`
+}
+
+type ForwarderGatewayRecordUnknownConfig struct {
+	// File points to a file on the local file system where
+	// unknown gateways that connect are recorded.
+	File string
+}
+
+type ForwarderGatewayConfig struct {
+	// Store describes how gateways are stored/loaded in the forwarder.
+	Store ForwarderGatewayStoreConfig
+
+	// RecordUnknown records gateways that connect to the forwarder but
+	// are not in the forwarders gateway store. Recorded gateways can
+	// be imported later if required.
+	RecordUnknown *ForwarderGatewayRecordUnknownConfig `mapstructure:"record_unknown"`
+	// RegistryAddress holds the address where the gateway registry is
+	// deployed on chain. It is used to retrieve gateway details to
+	// determine which gateways in the store are onboarded on ThingsIX
+	// and have their details. Once token support is integrated to ThingsIX
+	// only data for these gateways will be forwarded.
+	RegistryAddress *common.Address `mapstructure:"gateway_registry"`
+
+	// Refresh indicates the interval in which the gateway registry is
+	// used to check if gateways from the forwarders store are onboarded
+	// have their gateways set.
+	Refresh *time.Duration
+}
+
+type ForwarderRoutersOnChainConfig struct {
+	// RegistryContract indicates when non-nil that router information must
+	// be fetched from the registry smart contract (required blockchain cfg)
+	RegistryContract common.Address `mapstructure:"registry"`
+
+	// Interval indicates how often the routes are refreshed
+	UpdateInterval *time.Duration `mapstructure:"interval"`
+}
+
+type ForwarderRoutersThingsIXAPIConfig struct {
+	Endpoint *string
+	// Interval indicates how often the routes are refreshed
+	UpdateInterval *time.Duration `mapstructure:"interval"`
+}
+
+type ForwarderRoutersConfig struct {
+	// Default routers that will receive all gateway data unfiltered
+	Default []*Router
+
+	// OnChain idicates that ThingsIX routers are loaded from the router
+	// registry as deployed on the blockchain.
+	OnChain *ForwarderRoutersOnChainConfig `mapstructure:"on_chain"`
+
+	// ThingsIXApi indicates when non-nil that router information must be
+	// fetched from the ThingsIX API
+	ThingsIXApi *ForwarderRoutersThingsIXAPIConfig `mapstructure:"thingsix_api"`
+}
+
+type ForwarderConfig struct {
+	// Backend holdsconfiguration related to the forwarders gateway
+	// endpoint and supported protocol.
+	Backend ForwarderBackendConfig
+
+	// Gateways holds configuration related to gateways.
+	Gateways ForwarderGatewayConfig
+
+	Routers ForwarderRoutersConfig
+
+	// Optional account strategy configuration, if not specified no account is used meaning
+	// that all packets are exchanged between gateway and routers.
+	Accounting *struct{}
+}
+
+type LogConfig struct {
+	Level     logrus.Level
+	Timestamp bool
+}
+
+type BlockchainPolygonConfig struct {
+	Endpoint      string
+	ChainID       uint64 `mapstructure:"chain_id"`
+	Confirmations uint64
+}
+
+type BlockchainConfig struct {
+	Polygon *BlockchainPolygonConfig
+}
+
+type MetricsPrometheusConfig struct {
+	Address string
+	Path    string
+}
+
+type MetricsConfig struct {
+	Prometheus *MetricsPrometheusConfig
+}
+
+type Config struct {
+	Forwarder ForwarderConfig
+
+	Log LogConfig
+
+	BlockChain BlockchainConfig
+
+	Metrics *MetricsConfig
+}

--- a/forwarder/utils.go
+++ b/forwarder/utils.go
@@ -283,7 +283,7 @@ func fetchRoutersFromThingsIXAPI(cfg *Config, accounter Accounter) (RoutesUpdate
 		}
 	}
 
-	logrus.WithField("interval", interval).Info("retrieve routers from ThingsIX API")
+	logrus.WithField("interval", interval).WithField("api", *cfg.Forwarder.Routers.ThingsIXApi.Endpoint).Info("retrieve routers from ThingsIX API")
 
 	return func() ([]*Router, error) {
 		resp, err := http.Get(*cfg.Forwarder.Routers.ThingsIXApi.Endpoint)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/goreleaser/goreleaser v0.106.0
 	github.com/goreleaser/nfpm v0.11.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/icza/gog v0.0.0-20220909135443-35d926f98ec3
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/ThingsIXFoundation/h3-light v0.0.0-20221122151216-69018e780344 h1:faZ
 github.com/ThingsIXFoundation/h3-light v0.0.0-20221122151216-69018e780344/go.mod h1:jSChfHi3fbZIAHTaPSEy+ghN/kF32U/f+NZdQt6oDD8=
 github.com/ThingsIXFoundation/router-api v1.2.0 h1:f6B8BcX1BakGYYfRSknTtVPNtRgRX4hX+/Isb2L5TYA=
 github.com/ThingsIXFoundation/router-api v1.2.0/go.mod h1:jED1RkCsj3JM6I0rbjUTPTxOeJvPTYXqAu5E1uBSmVo=
-github.com/ThingsIXFoundation/router-registry-go v1.0.0 h1:BJr4yMXOyxDeqZqi1cEfXtlRCd70cx4Z2kcVCvcWUQg=
-github.com/ThingsIXFoundation/router-registry-go v1.0.0/go.mod h1:JA8B+SBQEL1MAvHrbNw053bSzq++BBwW7QJ/s7BH018=
 github.com/ThingsIXFoundation/router-registry-go v1.1.0 h1:zWZMhrc4ZuLVR5X2hsu1TVSpkQJo4xM/+oWMrW7bUK0=
 github.com/ThingsIXFoundation/router-registry-go v1.1.0/go.mod h1:JA8B+SBQEL1MAvHrbNw053bSzq++BBwW7QJ/s7BH018=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
@@ -260,6 +258,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/icza/gog v0.0.0-20220909135443-35d926f98ec3 h1:O8SoyXDpxP94MiNQQ4I8Va4qwNDWM6k4yygxhh/KNBw=
+github.com/icza/gog v0.0.0-20220909135443-35d926f98ec3/go.mod h1:DfGPW5hjxzL8lvxIU3S1/jYrehLWYdue9RDw0FFA/fI=
 github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
This PR adds support a default config for devnet, testnet and mainnet that can be set via a single `--net` parameter. 