### PR TITLE
Create empty gateway store if not exists

### DIFF
--- a/gateway/store_yaml_file.go
+++ b/gateway/store_yaml_file.go
@@ -203,12 +203,17 @@ func (store *yamlFileStore) Add(ctx context.Context, localID lorawan.EUI64, key 
 func (store *yamlFileStore) loadFromFile() error {
 	rawGateways, err := os.ReadFile(store.path)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return ErrStoreNotExists
-		}
-		if len(rawGateways) < 10 {
+		if errors.Is(err, os.ErrNotExist) {
+			// try to create it, on success return empty store
+			f, err := os.OpenFile(store.path, os.O_CREATE, 0600)
+			if err != nil {
+				return ErrStoreNotExists
+			}
+			f.Close()
+			printGatewayStoreChanges(nil, nil)
 			return nil
 		}
+		return err
 	}
 
 	var (


### PR DESCRIPTION
Currently the check to verify if the file based gateway store is read is incorrect. As a result the forwarder will use an empty store that doesn't exist.

With this PR the forwarder will try to create an empty store if it doesn't exist. If that fails, or the existing store could not be read it returns an error.