### PR TITLE
Support hex decode with 0x prefix

### DIFF
--- a/forwarder/utils.go
+++ b/forwarder/utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/chirpstack/chirpstack/api/go/v4/gw"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/olekukonko/tablewriter"
 	"github.com/sirupsen/logrus"
@@ -207,7 +208,7 @@ func fetchRoutersFromThingsIXAPI(cfg *Config, accounter Accounter) (RoutesUpdate
 			var (
 				id [32]byte
 			)
-			rID, err := hex.DecodeString(r.ID)
+			rID, err := hexutil.Decode(r.ID)
 			if err != nil {
 				logrus.WithError(err).Error("unable to decode router id")
 				continue


### PR DESCRIPTION
As reported through discord. The new data-aggregator API prefixes the router id while the old API didn't. This PR adds support to decode with and without 0x prefix.