### PR TITLE
Add network name to metadata

### DIFF
--- a/forwarder/metadata.go
+++ b/forwarder/metadata.go
@@ -29,6 +29,7 @@ import (
 func setChaindataInFrameMetadata(frame *gw.UplinkFrame, gw *gateway.Gateway, airtime time.Duration) {
 	frame.RxInfo.Metadata = map[string]string{}
 	metadata := frame.RxInfo.Metadata
+	metadata["network"] = "thingsix"
 	metadata["thingsix_gateway_id"] = gw.ID().String()
 	metadata["thingsix_airtime_ms"] = fmt.Sprintf("%d", airtime.Milliseconds())
 


### PR DESCRIPTION
See:
* https://github.com/helium/helium-packet-router/issues/285
* https://github.com/helium/helium-packet-router/pull/286

In the metadata for a gateway that is sent to ChirpStack, explicitly state that this packet comes from the ThingsIX network. This would help services on the other side of ChirpStack know for sure if the packet was received by ThingsIX, without having to guess from the other metadata fields.